### PR TITLE
Change mapping to be 1:1

### DIFF
--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -18,6 +18,7 @@ interface Props {
   title: string;
   subTitle?: string;
   confirmationText?: string;
+  cancelText?: string;
   onConfirm: () => void;
   variant?: VariantType;
 }
@@ -28,6 +29,7 @@ export default function ConfirmationModal({
   title,
   subTitle,
   confirmationText,
+  cancelText,
   onConfirm,
   variant = 'default',
 }: Props) {
@@ -108,7 +110,7 @@ export default function ConfirmationModal({
                   data-autofocus
                   onClick={() => setOpen(false)}
                 >
-                  {t('components.confirmationModal.cancel')}
+                  {cancelText ?? t('components.confirmationModal.cancel')}
                 </Button>
               </div>
             </div>

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -4,8 +4,11 @@ import {
   ListboxOption,
   ListboxOptions,
 } from '@headlessui/react';
-import { ChevronUpDownIcon } from '@heroicons/react/16/solid';
-import { CheckIcon } from '@heroicons/react/20/solid';
+import {
+  ChevronUpDownIcon,
+  XMarkIcon,
+  CheckIcon,
+} from '@heroicons/react/20/solid';
 
 export interface SelectOption<T> {
   label: string;
@@ -19,6 +22,7 @@ interface Props<T> {
   onChange: (value: T[] | T | null) => void;
   multiple?: boolean;
   compareFunction?: (a: T, b: T) => boolean;
+  clearable?: boolean;
 }
 
 export default function Select<T>({
@@ -27,9 +31,8 @@ export default function Select<T>({
   onChange,
   multiple = false,
   compareFunction = (a, b) => a === b,
+  clearable = false,
 }: Props<T>) {
-  // TODO: Add support for clearable and searchable
-
   const isSelected = (valueToCheck: T) => {
     if (multiple && Array.isArray(value)) {
       return value.some((selected) => compareFunction(selected, valueToCheck));
@@ -46,6 +49,14 @@ export default function Select<T>({
     }
   };
 
+  const clear = () => {
+    if (multiple) {
+      onChange([]);
+    } else {
+      onChange(null);
+    }
+  };
+
   const selectedOptions = options.filter((option) => isSelected(option.value));
 
   return (
@@ -57,6 +68,22 @@ export default function Select<T>({
               ? selectedOptions.map((o) => o.label).join(', ')
               : 'Select an option'}
           </span>
+
+          {clearable && selectedOptions.length > 0 && (
+            <span
+              onClick={(e) => {
+                e.stopPropagation();
+                clear();
+              }}
+              className="absolute inset-y-0 right-8 flex cursor-pointer items-center pr-2"
+            >
+              <XMarkIcon
+                className="h-5 w-5 text-gray-500 hover:text-gray-700"
+                aria-hidden="true"
+              />
+            </span>
+          )}
+
           <ChevronUpDownIcon
             aria-hidden="true"
             className="col-start-1 row-start-1 size-5 self-center justify-self-end text-gray-500 sm:size-4"
@@ -81,7 +108,7 @@ export default function Select<T>({
 
               {isSelected(option.value) && (
                 <span className="text-primary absolute inset-y-0 right-0 flex items-center pr-4 group-data-focus:text-white">
-                  <CheckIcon aria-hidden="true" className="size-5" />
+                  <CheckIcon aria-hidden="true" className="h-5 w-5" />
                 </span>
               )}
             </ListboxOption>

--- a/src/i18/en/translation.json
+++ b/src/i18/en/translation.json
@@ -7,6 +7,7 @@
   },
   "importer": {
     "upload": "Upload",
+    "back": "Back",
     "loader": {
       "failed": "Something went wrong",
       "uploading": "Uploading",
@@ -19,6 +20,12 @@
       "fileSizeLimit": "Limit {{limit}}",
       "browseFiles": "Browse Files",
       "enterManually": "Or just manually enter your data"
+    },
+    "backToMappingConfirmation": {
+      "title": "Are you sure?",
+      "subTitle": "This will discard all changes made after the data was mapped",
+      "confirmationText": "Yes, go back",
+      "cancelText": "No, stay here"
     }
   },
   "mapper": {

--- a/src/i18/fr/translation.json
+++ b/src/i18/fr/translation.json
@@ -7,6 +7,7 @@
   },
   "importer": {
     "upload": "Télécharger",
+    "back": "Retour",
     "loader": {
       "failed": "Quelque chose a mal tourné",
       "uploading": "Téléchargement en cours",
@@ -19,6 +20,12 @@
       "fileSizeLimit": "Limite {{limit}}",
       "browseFiles": "Parcourir les fichiers",
       "enterManually": "Ou saisissez vos données manuellement"
+    },
+    "backToMappingConfirmation": {
+      "title": "Êtes-vous sûr ?",
+      "subTitle": "Cela annulera toutes les modifications effectuées après le mappage des données",
+      "confirmationText": "Oui, revenir en arrière",
+      "cancelText": "Non, rester ici"
     }
   },
   "mapper": {

--- a/src/importer/components/BackToMappingButton.tsx
+++ b/src/importer/components/BackToMappingButton.tsx
@@ -20,6 +20,7 @@ export default function BackToMappingButton({ onBackToMapping }: Props) {
         {t('importer.back')}
       </Button>
       <ConfirmationModal
+        variant="danger"
         onConfirm={onBackToMapping}
         open={confirmationModalOpen}
         setOpen={setConfirmationModalOpen}

--- a/src/importer/components/BackToMappingButton.tsx
+++ b/src/importer/components/BackToMappingButton.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'preact/hooks';
+import { Button, ConfirmationModal } from '../../components';
+import { useTranslations } from '../../i18';
+
+interface Props {
+  onBackToMapping: () => void;
+}
+
+export default function BackToMappingButton({ onBackToMapping }: Props) {
+  const { t } = useTranslations();
+
+  const [confirmationModalOpen, setConfirmationModalOpen] = useState(false);
+
+  return (
+    <>
+      <Button
+        onClick={() => setConfirmationModalOpen(true)}
+        variant="secondary"
+      >
+        {t('importer.back')}
+      </Button>
+      <ConfirmationModal
+        onConfirm={onBackToMapping}
+        open={confirmationModalOpen}
+        setOpen={setConfirmationModalOpen}
+        title={t('importer.backToMappingConfirmation.title')}
+        subTitle={t('importer.backToMappingConfirmation.subTitle')}
+        confirmationText={t(
+          'importer.backToMappingConfirmation.confirmationText'
+        )}
+        cancelText={t('importer.backToMappingConfirmation.cancelText')}
+      />
+    </>
+  );
+}

--- a/src/importer/index.tsx
+++ b/src/importer/index.tsx
@@ -22,6 +22,7 @@ import { NUMBER_OF_EMPTY_ROWS_FOR_MANUAL_DATA_INPUT } from '../constants';
 import SheetsSwitcher from '../sheet/components/SheetsSwitcher';
 import { Button, Root } from '../components';
 import { TranslationProvider, useTranslations } from '../i18';
+import BackToMappingButton from './components/BackToMappingButton';
 
 function ImporterBody({
   theme,
@@ -88,12 +89,7 @@ function ImporterBody({
   }
 
   async function onMappingsSet() {
-    const mappedData = getMappedData(
-      sheets,
-      columnMappings ?? [],
-      parsedFile!,
-      sheetData
-    );
+    const mappedData = getMappedData(sheets, columnMappings ?? [], parsedFile!);
 
     const newMappedData =
       onDataColumnsMapped != null
@@ -138,6 +134,10 @@ function ImporterBody({
     dispatch({ type: 'PREVIEW' });
   }
 
+  function onBackToMapping() {
+    dispatch({ type: 'MAPPING' });
+  }
+
   return (
     <ThemeSetter theme={theme}>
       <Root>
@@ -148,6 +148,7 @@ function ImporterBody({
             currentMapping={columnMappings ?? []}
             onMappingsChanged={onMappingsChanged}
             onMappingsSet={onMappingsSet}
+            onBack={onBackToPreview}
           />
         )}
         {mode === 'preview' && (
@@ -171,8 +172,15 @@ function ImporterBody({
               removeRows={onRemoveRows}
             />
             {currentSheetData.rows.length > 0 && (
-              <div className="my-5 text-right">
-                <Button onClick={onSubmit}>{t('importer.upload')}</Button>
+              <div className="my-5 flex justify-between">
+                <div>
+                  {columnMappings != null && (
+                    <BackToMappingButton onBackToMapping={onBackToMapping} />
+                  )}
+                </div>
+                <div>
+                  <Button onClick={onSubmit}>{t('importer.upload')}</Button>
+                </div>
               </div>
             )}
 

--- a/src/importer/reducer.ts
+++ b/src/importer/reducer.ts
@@ -24,15 +24,10 @@ const reducer = (
     case 'ENTER_DATA_MANUALLY': {
       const emptyData = state.sheetDefinitions.map((sheet) => ({
         sheetId: sheet.id,
-        rows:
-          state.currentSheetId === sheet.id
-            ? Array.from(
-                { length: action.payload.amountOfEmptyRowsToAdd },
-                () => ({})
-              )
-            : state.sheetData.find(
-                (sheetData) => sheetData.sheetId === sheet.id
-              )?.rows || [],
+        rows: Array.from(
+          { length: action.payload.amountOfEmptyRowsToAdd },
+          () => ({})
+        ),
       }));
 
       return { ...state, mode: 'preview', sheetData: emptyData };
@@ -114,6 +109,8 @@ const reducer = (
       return { ...state, mode: 'failed' };
     case 'PREVIEW':
       return { ...state, mode: 'preview' };
+    case 'MAPPING':
+      return { ...state, mode: 'mapping' };
     default:
       return state;
   }

--- a/src/importer/types.ts
+++ b/src/importer/types.ts
@@ -86,4 +86,5 @@ export type ImporterAction =
   | { type: 'PROGRESS'; payload: { progress: number } } // Updates importProgress
   | { type: 'COMPLETED' } // Changes the mode to 'completed'
   | { type: 'FAILED' } // Changes the mode to 'failed' when importing failed
-  | { type: 'PREVIEW' }; // Changes the mode to 'preview' - used when uploading failed and user wants to retry
+  | { type: 'PREVIEW' } // Changes the mode to 'preview' - used when uploading failed and user wants to retry
+  | { type: 'MAPPING' }; // Changes the mode to 'mapping' - used to go back to mappings screen in case there were some mapping issues

--- a/src/mapper/components/HeaderMapperRow.tsx
+++ b/src/mapper/components/HeaderMapperRow.tsx
@@ -7,26 +7,25 @@ interface Props {
   csvHeader: string;
   mappingSelectionOptions: MapperOption[];
   examples: ImporterOutputFieldType[];
-  currentMappings: ColumnMapping[];
-  setMappings: (mappings: MapperOptionValue[] | null) => void;
+  currentMapping: ColumnMapping | null;
+  setMapping: (mappings: MapperOptionValue | null) => void;
 }
 
 export default function HeaderMapperRow({
   mappingSelectionOptions,
   csvHeader,
   examples,
-  currentMappings,
-  setMappings,
+  currentMapping,
+  setMapping,
 }: Props) {
-  const currentHeaderOptions = mappingSelectionOptions
-    .filter((option) =>
-      currentMappings.some(
-        (mapping) =>
-          mapping.sheetId === option.value.sheetId &&
-          mapping.sheetColumnId === option.value.sheetColumnId
-      )
-    )
-    .map((option) => option.value);
+  const currentHeaderOption =
+    currentMapping == null
+      ? null
+      : (mappingSelectionOptions.find(
+          (option) =>
+            option.value.sheetId === currentMapping.sheetId &&
+            option.value.sheetColumnId === currentMapping.sheetColumnId
+        )?.value ?? null);
 
   return (
     <div className="my-5">
@@ -35,8 +34,8 @@ export default function HeaderMapperRow({
           mappingSelectionOptions={mappingSelectionOptions}
           csvHeader={csvHeader}
           examples={examples}
-          currentMappings={currentHeaderOptions}
-          setMappings={setMappings}
+          currentMapping={currentHeaderOption}
+          setMapping={setMapping}
         />
       </Card>
     </div>

--- a/src/mapper/components/HeaderMapperSelection.tsx
+++ b/src/mapper/components/HeaderMapperSelection.tsx
@@ -11,16 +11,16 @@ import { ArrowRightIcon } from '@heroicons/react/24/outline';
 interface Props {
   csvHeader: string;
   examples: ImporterOutputFieldType[];
-  currentMappings: MapperOptionValue[] | null;
-  setMappings: (header: MapperOptionValue[] | null) => void;
+  currentMapping: MapperOptionValue | null;
+  setMapping: (header: MapperOptionValue | null) => void;
   mappingSelectionOptions: MapperOption[];
 }
 
 export default function HeaderMapperSelection({
   csvHeader,
   examples,
-  setMappings,
-  currentMappings,
+  setMapping,
+  currentMapping,
   mappingSelectionOptions,
 }: Props) {
   const { t } = useTranslations();
@@ -38,15 +38,18 @@ export default function HeaderMapperSelection({
             // TODO THIS BRANCH: Add back the following props
             // isClearable
             // isSearchable
-            compareFunction={(a, b) =>
-              a.sheetColumnId === b.sheetColumnId && a.sheetId === b.sheetId
-            }
-            multiple
-            value={currentMappings}
+            compareFunction={(a, b) => {
+              if (a == null || b == null) {
+                return false;
+              }
+
+              return (
+                a.sheetColumnId === b.sheetColumnId && a.sheetId === b.sheetId
+              );
+            }}
+            value={currentMapping}
             options={mappingSelectionOptions}
-            onChange={(mappings) =>
-              setMappings(mappings as ColumnMapping[] | null)
-            }
+            onChange={(mapping) => setMapping(mapping as ColumnMapping | null)}
           />
         </div>
       </div>

--- a/src/mapper/components/HeaderMapperSelection.tsx
+++ b/src/mapper/components/HeaderMapperSelection.tsx
@@ -36,8 +36,8 @@ export default function HeaderMapperSelection({
         <div className="flex-4">
           <Select
             // TODO THIS BRANCH: Add back the following props
-            // isClearable
             // isSearchable
+            clearable
             compareFunction={(a, b) => {
               if (a == null || b == null) {
                 return false;

--- a/src/mapper/index.ts
+++ b/src/mapper/index.ts
@@ -1,47 +1,87 @@
-import { ParsedFile, SheetDefinition, SheetRow, SheetState } from '../types';
+import { ParsedFile, SheetDefinition, SheetRow } from '../types';
 import { ColumnMapping, MappedData } from './types';
 
 export { default as HeaderMapper } from './components/HeaderMapper';
 
+function mapReferenceColumns(
+  sheetDefinitions: SheetDefinition[],
+  mappedData: MappedData
+): MappedData {
+  return mappedData.map((sheetData) => {
+    const sheetDefinition = sheetDefinitions.find(
+      (definition) => definition.id === sheetData.sheetId
+    );
+
+    if (sheetDefinition == null) {
+      return sheetData;
+    }
+
+    const rows = sheetData.rows.map((row, rowIndex) => {
+      const newRow: SheetRow = { ...row };
+
+      sheetDefinition.columns
+        .filter((column) => column.type === 'reference')
+        .forEach((column) => {
+          const referenceSheetData = mappedData.find(
+            (data) => data.sheetId === column.typeArguments.sheetId
+          );
+
+          if (referenceSheetData != null) {
+            const referenceColumn = referenceSheetData.rows.map(
+              (r) => r[column.typeArguments.sheetColumnId]
+            );
+
+            const referenceValue = referenceColumn[rowIndex];
+
+            newRow[column.id] = referenceValue;
+          }
+        });
+
+      return newRow;
+    });
+
+    return {
+      ...sheetData,
+      rows,
+    };
+  });
+}
+
 export function getMappedData(
   sheetDefinitions: SheetDefinition[],
   mappings: ColumnMapping[],
-  parsedFile: ParsedFile,
-  currentData: SheetState[]
+  parsedFile: ParsedFile
 ): MappedData {
   const data = parsedFile.data;
 
-  return sheetDefinitions.map((sheetDefinition) => {
-    let rows: SheetRow[] = [];
+  const mappedData = sheetDefinitions.map((sheetDefinition) => {
+    const rows: SheetRow[] = [];
 
     const sheetMappings = mappings.filter(
       (mapping) => mapping.sheetId === sheetDefinition.id
     );
 
-    if (sheetMappings.length === 0) {
-      rows =
-        currentData.find((d) => d.sheetId === sheetDefinition.id)?.rows || [];
-    } else {
-      data.map((row) => {
-        const newRow: SheetRow = {};
+    data.map((row) => {
+      const newRow: SheetRow = {};
 
-        sheetDefinition.columns.forEach((column) => {
-          const mapping = sheetMappings.find(
-            (mapping) => mapping.sheetColumnId === column.id
-          );
+      sheetDefinition.columns.forEach((column) => {
+        const mapping = sheetMappings.find(
+          (mapping) => mapping.sheetColumnId === column.id
+        );
 
-          if (mapping != null) {
-            newRow[mapping.sheetColumnId] = row[mapping.csvColumnName];
-          }
-        });
-
-        rows.push(newRow);
+        if (mapping != null) {
+          newRow[mapping.sheetColumnId] = row[mapping.csvColumnName];
+        }
       });
-    }
+
+      rows.push(newRow);
+    });
 
     return {
       sheetId: sheetDefinition.id,
       rows,
     };
   });
+
+  return mapReferenceColumns(sheetDefinitions, mappedData);
 }

--- a/src/mapper/utils.ts
+++ b/src/mapper/utils.ts
@@ -81,7 +81,7 @@ export function calculateNewMappingsForCsvColumnMapingChanged(
   newCsvColumnMaping: MapperOptionValue | null
 ): ColumnMapping[] {
   if (newCsvColumnMaping == null) {
-    return currentMapping;
+    return currentMapping.filter((m) => m.csvColumnName !== csvColumnName);
   }
 
   // Make sure we don't allow dupplicate mappings for the same sheet column

--- a/src/sheet/types.ts
+++ b/src/sheet/types.ts
@@ -20,6 +20,7 @@ export type SheetColumnDefinition =
 interface SheetColumnBaseDefinition {
   id: string;
   label: string;
+  suggestedMappingKeywords?: string[];
   isReadOnly?: boolean;
   validators?: ImporterValidatorDefinition[];
   transformers?: ImporterTransformerDefinition[];


### PR DESCRIPTION
Added things
- Now mapping can only be 1:1
- Now we don't display sheet name in mapping select
- Now we allow go back to mapping with confirmation - going back itself shouldn't override the data but going back and clicking confirm would
- Now we allow to go back from mapping to preview
- Now we always map all the data, even if some sheet doesn't have any mapped column
- Now we don't allow to confirm mapping when there are some required columns that are not mapped
- Now we don't include reference columns in mapping select options
- Now we automatically map reference columns
- Now when generating suggested mappings we only get the first mapped column
- Now we allow to pass suggestedMappingKeywords to sheet column definition to help the suggested mapper
- Now we don't include already mapped columns in mapper selection
- Now we can clear mapping selection in Select component