### PR TITLE
Custom translation resource support

### DIFF
--- a/docs/v0.3.0/api-reference/importer-props.mdx
+++ b/docs/v0.3.0/api-reference/importer-props.mdx
@@ -139,3 +139,14 @@ Use cases for `customKey`:
 - **Session Management**: You can use the `customKey` to implement session-specific storage, allowing you to clear specific import sessions without affecting others.
 
 ---
+
+## translationResources
+
+**Type:** `Record<string, Translation>`
+
+**Required:** No
+
+**Description:**  
+A dictionary of translations for the importer component. The keys are the locale codes, and the values are the translations.
+
+---

--- a/src/i18/fr/translation.json
+++ b/src/i18/fr/translation.json
@@ -90,6 +90,8 @@
     "successDescriptionWithStats": "{{recordsImported}} sur {{totalRecords}} enregistrements ont été importés avec succès",
     "error": "Importation échouée",
     "errorDescription": "Une erreur est survenue lors de l'importation. Veuillez réessayer",
+    "importFailed": "Importation échouée",
+    "failedDescription": "Une erreur est survenue lors de l'importation. Veuillez réessayer",
     "importDetails": "Détails de l'importation",
     "importDetailsDescription": "Détails sur votre dernière importation",
     "fileInformation": "Informations sur le fichier",

--- a/src/i18/index.tsx
+++ b/src/i18/index.tsx
@@ -83,7 +83,7 @@ export function TranslationProvider({
 }: {
   children: ReactNode;
   selectedLocale?: string;
-  translationResources?: Resources;
+  translationResources?: Record<string, Translation>;
 }) {
   const locale = selectedLocale ?? defaultLocale;
 

--- a/src/i18/index.tsx
+++ b/src/i18/index.tsx
@@ -11,20 +11,32 @@ import {
   TranslationContextType,
 } from './types';
 
-/// Writing a custom translations module to reduce the size of the package
+type Prettify<T> = {
+  [K in keyof T]: T[K] extends object ? Prettify<T[K]> : T[K];
+} & unknown;
 
-const resources: Resources = {
+type CreateTranslation<T> = {
+  [K in keyof T]: T[K] extends string
+    ? string
+    : T[K] extends object
+      ? CreateTranslation<T[K]>
+      : T[K];
+};
+
+export type Translation = Prettify<CreateTranslation<typeof enTranslation>>;
+
+const resources: Record<string, Translation | undefined> = {
   en: enTranslation,
   fr: frTranslation,
   'pt-BR': ptBRTranslation,
-};
+} satisfies Resources;
 
 const defaultLocale = 'en';
 
-function extractTranslation(currentLocale: string, key: string) {
+function extractTranslation(currentLocale: string, key: string, translationResources?: Resources) {
   const keyParts = key.split('.');
 
-  let result: any = resources[currentLocale];
+  let result: any = translationResources?.[currentLocale] ?? resources[currentLocale];
 
   for (const k of keyParts) {
     if (result && typeof result === 'object') {
@@ -80,14 +92,16 @@ const TranslationContext = createContext<TranslationContextType>(
 export function TranslationProvider({
   children,
   selectedLocale,
+  translationResources,
 }: {
   children: ReactNode;
   selectedLocale?: string;
+  translationResources?: Resources;
 }) {
   const locale = selectedLocale ?? defaultLocale;
 
   function t(key: string, argumentValues: ArgumentsTypeText = {}): string {
-    const translation = extractTranslation(locale, key);
+    const translation = extractTranslation(locale, key, translationResources);
 
     return replaceArguments(translation, argumentValues);
   }
@@ -96,7 +110,7 @@ export function TranslationProvider({
     key: string,
     argumentValues: ArgumentsTypeHtml = {}
   ): ReactNode {
-    const translation = extractTranslation(locale, key);
+    const translation = extractTranslation(locale, key, translationResources);
 
     return replaceArgumentsHtml(translation, argumentValues);
   }

--- a/src/i18/index.tsx
+++ b/src/i18/index.tsx
@@ -8,22 +8,9 @@ import {
   ArgumentsTypeHtml,
   ArgumentsTypeText,
   Resources,
+  Translation,
   TranslationContextType,
 } from './types';
-
-type Prettify<T> = {
-  [K in keyof T]: T[K] extends object ? Prettify<T[K]> : T[K];
-} & unknown;
-
-type CreateTranslation<T> = {
-  [K in keyof T]: T[K] extends string
-    ? string
-    : T[K] extends object
-      ? CreateTranslation<T[K]>
-      : T[K];
-};
-
-export type Translation = Prettify<CreateTranslation<typeof enTranslation>>;
 
 const resources: Record<string, Translation | undefined> = {
   en: enTranslation,

--- a/src/i18/index.tsx
+++ b/src/i18/index.tsx
@@ -20,10 +20,15 @@ const resources: Record<string, Translation | undefined> = {
 
 const defaultLocale = 'en';
 
-function extractTranslation(currentLocale: string, key: string, translationResources?: Resources) {
+function extractTranslation(
+  currentLocale: string,
+  key: string,
+  translationResources?: Resources
+) {
   const keyParts = key.split('.');
 
-  let result: any = translationResources?.[currentLocale] ?? resources[currentLocale];
+  let result: any =
+    translationResources?.[currentLocale] ?? resources[currentLocale];
 
   for (const k of keyParts) {
     if (result && typeof result === 'object') {

--- a/src/i18/types.ts
+++ b/src/i18/types.ts
@@ -1,4 +1,5 @@
 import { ReactNode } from 'preact/compat';
+import type enTranslation from './en/translation.json';
 
 type TranslationValue = string | { [key: string]: TranslationValue };
 export type Translations = Record<string, TranslationValue>;
@@ -15,3 +16,17 @@ export type TranslationContextType = {
   t: (key: string, argumentValues?: ArgumentsTypeText) => string;
   tHtml: (key: string, argumentValues?: ArgumentsTypeHtml) => ReactNode;
 };
+
+type Prettify<T> = {
+  [K in keyof T]: T[K] extends object ? Prettify<T[K]> : T[K];
+} & unknown;
+
+type CreateTranslation<T> = {
+  [K in keyof T]: T[K] extends string
+    ? string
+    : T[K] extends object
+      ? CreateTranslation<T[K]>
+      : T[K];
+};
+
+export type Translation = Prettify<CreateTranslation<typeof enTranslation>>;

--- a/src/importer/index.tsx
+++ b/src/importer/index.tsx
@@ -282,7 +282,10 @@ function ImporterBody({
 
 export default function Importer(props: ImporterDefinition) {
   return (
-    <TranslationProvider selectedLocale={props.locale}>
+    <TranslationProvider
+      selectedLocale={props.locale}
+      translationResources={props.translationResources}
+    >
       <ImporterBody {...props} />
     </TranslationProvider>
   );

--- a/src/importer/types.ts
+++ b/src/importer/types.ts
@@ -1,5 +1,4 @@
-import { Translation } from '../i18';
-import {
+import type {
   ThemeVariant,
   ImporterValidationError,
   ParsedFile,
@@ -10,6 +9,7 @@ import {
   ColumnMapping,
   SheetRow,
   ImportStatistics,
+  Translation,
 } from '../types';
 
 // --------- Importer Definition Types ---------
@@ -27,8 +27,8 @@ export interface ImporterDefinition {
   ) => Promise<void> | Promise<ImportStatistics>;
   locale?: string;
   preventUploadOnValidationErrors?:
-  | boolean
-  | ((errors: ImporterValidationError[]) => boolean);
+    | boolean
+    | ((errors: ImporterValidationError[]) => boolean);
   maxFileSizeInBytes?: number;
   onSummaryFinished?: () => void;
   customSuggestedMapper?: (
@@ -86,29 +86,29 @@ export interface RemoveRowsPayload {
 
 export type ImporterAction =
   | {
-    type: 'ENTER_DATA_MANUALLY';
-    payload: {
-      amountOfEmptyRowsToAdd: number;
-    };
-  } // Changes the mode to 'preview'
+      type: 'ENTER_DATA_MANUALLY';
+      payload: {
+        amountOfEmptyRowsToAdd: number;
+      };
+    } // Changes the mode to 'preview'
   | {
-    type: 'FILE_PARSED';
-    payload: { parsed: ParsedFile; rowFile: File };
-  } // Sets the parsed file and changes the mode to 'mapping'
+      type: 'FILE_PARSED';
+      payload: { parsed: ParsedFile; rowFile: File };
+    } // Sets the parsed file and changes the mode to 'mapping'
   | { type: 'UPLOAD' } // Changes the mode to 'upload' - used when going back from in the mapping screen
   | { type: 'COLUMN_MAPPING_CHANGED'; payload: { mappings: ColumnMapping[] } } // Sets the proper mappings
   | { type: 'DATA_MAPPED'; payload: { mappedData: MappedData } } // Sets mapped data as sheetData, optionally runs onDataColumnsMapped callback calls validations, changes the mode to 'preview'
   | {
-    type: 'CELL_CHANGED';
-    payload: CellChangedPayload;
-  } // Searches for the cell and changes the value, calls validations
+      type: 'CELL_CHANGED';
+      payload: CellChangedPayload;
+    } // Searches for the cell and changes the value, calls validations
   | {
-    type: 'REMOVE_ROWS';
-    payload: RemoveRowsPayload;
-  } // Removes rows from the sheetData
+      type: 'REMOVE_ROWS';
+      payload: RemoveRowsPayload;
+    } // Removes rows from the sheetData
   | {
-    type: 'ADD_EMPTY_ROW';
-  } // Removes rows from the sheetData
+      type: 'ADD_EMPTY_ROW';
+    } // Removes rows from the sheetData
   | { type: 'SHEET_CHANGED'; payload: { sheetId: string } } // Calls onComplete callback with state.sheetData, changes mode to 'submit'
   | { type: 'SUBMIT' } // Calls onComplete callback with state.sheetData, changes mode to 'submit'
   | { type: 'PROGRESS'; payload: { progress: number } } // Updates importProgress

--- a/src/importer/types.ts
+++ b/src/importer/types.ts
@@ -1,3 +1,4 @@
+import { Translation } from '../i18';
 import {
   ThemeVariant,
   ImporterValidationError,
@@ -15,6 +16,7 @@ import {
 
 export interface ImporterDefinition {
   sheets: SheetDefinition[];
+  translationResources?: Record<string, Translation>;
   theme?: ThemeVariant;
   // Called after the columns are mapped to sheet definitions by the user
   onDataColumnsMapped?: OnDataColumnsMappedCallback;
@@ -25,8 +27,8 @@ export interface ImporterDefinition {
   ) => Promise<void> | Promise<ImportStatistics>;
   locale?: string;
   preventUploadOnValidationErrors?:
-    | boolean
-    | ((errors: ImporterValidationError[]) => boolean);
+  | boolean
+  | ((errors: ImporterValidationError[]) => boolean);
   maxFileSizeInBytes?: number;
   onSummaryFinished?: () => void;
   customSuggestedMapper?: (
@@ -84,29 +86,29 @@ export interface RemoveRowsPayload {
 
 export type ImporterAction =
   | {
-      type: 'ENTER_DATA_MANUALLY';
-      payload: {
-        amountOfEmptyRowsToAdd: number;
-      };
-    } // Changes the mode to 'preview'
+    type: 'ENTER_DATA_MANUALLY';
+    payload: {
+      amountOfEmptyRowsToAdd: number;
+    };
+  } // Changes the mode to 'preview'
   | {
-      type: 'FILE_PARSED';
-      payload: { parsed: ParsedFile; rowFile: File };
-    } // Sets the parsed file and changes the mode to 'mapping'
+    type: 'FILE_PARSED';
+    payload: { parsed: ParsedFile; rowFile: File };
+  } // Sets the parsed file and changes the mode to 'mapping'
   | { type: 'UPLOAD' } // Changes the mode to 'upload' - used when going back from in the mapping screen
   | { type: 'COLUMN_MAPPING_CHANGED'; payload: { mappings: ColumnMapping[] } } // Sets the proper mappings
   | { type: 'DATA_MAPPED'; payload: { mappedData: MappedData } } // Sets mapped data as sheetData, optionally runs onDataColumnsMapped callback calls validations, changes the mode to 'preview'
   | {
-      type: 'CELL_CHANGED';
-      payload: CellChangedPayload;
-    } // Searches for the cell and changes the value, calls validations
+    type: 'CELL_CHANGED';
+    payload: CellChangedPayload;
+  } // Searches for the cell and changes the value, calls validations
   | {
-      type: 'REMOVE_ROWS';
-      payload: RemoveRowsPayload;
-    } // Removes rows from the sheetData
+    type: 'REMOVE_ROWS';
+    payload: RemoveRowsPayload;
+  } // Removes rows from the sheetData
   | {
-      type: 'ADD_EMPTY_ROW';
-    } // Removes rows from the sheetData
+    type: 'ADD_EMPTY_ROW';
+  } // Removes rows from the sheetData
   | { type: 'SHEET_CHANGED'; payload: { sheetId: string } } // Calls onComplete callback with state.sheetData, changes mode to 'submit'
   | { type: 'SUBMIT' } // Calls onComplete callback with state.sheetData, changes mode to 'submit'
   | { type: 'PROGRESS'; payload: { progress: number } } // Updates importProgress


### PR DESCRIPTION
## Problem

We want to use HelloCSV in our product, but it currently doesn't support the `ko` (Korean 한국어) translation.

But... the more languages this library supports, the larger its bundle size becomes.
And... users of the library might want to customize labels and messages to match their brand tone.

## Solution

We would like to provide custom translation resources via props.

https://github.com/HelloCSV/HelloCSV/blob/main/src/i18/index.tsx

But what happens if a translation key is added in a future version and we miss it?

We can use a stronger type definition (the `Translation` type) to catch missing keys (e.g., `importFailed` and `failedDescription` in the `fr` translation).