### PR TITLE
fix: use defaultValue for inline editing

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -50,7 +50,7 @@ const Input = forwardRef<HTMLInputElement, Props>(
           type={type}
           inputMode={type === 'number' ? 'numeric' : 'text'}
           placeholder={placeholder}
-          value={value}
+          defaultValue={value}
           onChange={(e) => onChange?.(getParsedValue(e))}
           className={`${classes} ${iconBuilder != null ? 'pl-10' : ''} ${clearable ? 'pr-10' : ''} focus:outline-hello-csv-primary col-start-1 row-start-1 block rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 sm:text-sm/6`}
           onBlur={(e) => onBlur?.(getParsedValue(e))}


### PR DESCRIPTION
## Problem

We can't use inline editing feature in preview with `react`

## Solution

use `defaultValue` prop instead of `value`

https://react.dev/reference/react-dom/components/input#providing-an-initial-value-for-an-input