### PR TITLE
custom filer loaders support

### DIFF
--- a/docs/v0.3.0/api-reference/importer-props.mdx
+++ b/docs/v0.3.0/api-reference/importer-props.mdx
@@ -153,7 +153,7 @@ A dictionary of translations for the importer component. The keys are the locale
 
 ## customFileLoaders
 
-**Type:** `{ mimeType: string; label: string; convert: (loadEvent: ProgressEvent<FileReader>, file: File) => { fileName: string; csvData: string; }; }[]`
+**Type:** `{ mimeType: string; label: string; convert: (loadEvent: ProgressEvent<FileReader>, file: File) => { fileName: string; csvData: string; } | Promise<{ fileName: string; csvData: string; }>; }[]`
 
 **Required:** No
 

--- a/docs/v0.3.0/api-reference/importer-props.mdx
+++ b/docs/v0.3.0/api-reference/importer-props.mdx
@@ -150,3 +150,43 @@ Use cases for `customKey`:
 A dictionary of translations for the importer component. The keys are the locale codes, and the values are the translations.
 
 ---
+
+## customFileLoaders
+
+**Type:** `{ mimeType: string; label: string; convert: (loadEvent: ProgressEvent<FileReader>, file: File) => { fileName: string; csvData: string; }; }[]`
+
+**Required:** No
+
+**Description:**  
+A list of custom file loaders for the importer component.
+
+Use cases for `customFileLoaders`:
+
+- **Custom File Types**: When you need to import files with custom formats(like XLSX), you can create a custom file loader to handle the conversion process.
+
+**Example:**
+
+```typescript
+// Excel upload using xlsx library
+import * as XLSX from 'xlsx';
+
+const XLSX_FILE_MIME_TYPE =
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+
+<Importer
+  customFileLoaders={[
+    {
+      mimeType: XLSX_FILE_MIME_TYPE,
+      label: 'XLSX',
+      convert: (loadEvent, file) => {
+        const data = new Uint8Array(loadEvent.target?.result as ArrayBuffer);
+        const workbook = XLSX.read(data, { type: 'array' });
+        const firstSheet = workbook.Sheets[workbook.SheetNames[0]];
+        const csvData = XLSX.utils.sheet_to_csv(firstSheet);   
+
+        return { fileName: file.name, csvData };
+      },
+    },
+  ]}
+/>
+```

--- a/src/importer/index.tsx
+++ b/src/importer/index.tsx
@@ -79,16 +79,17 @@ function ImporterBody({
 
   const preventUpload = preventUploadOnErrors && validationErrors.length > 0;
 
-
-
   function onFileUploaded(file: File) {
+    const matchedCustomFileLoader = customFileLoaders?.find(
+      (loader) => loader.mimeType === file.type
+    );
 
-    const matchedCustomFileLoader = customFileLoaders?.find(loader => loader.mimeType === file.type);
-
-    const csvFilePromise: Promise<File> = matchedCustomFileLoader ?
-      loadFile(file)
-        .then(event => {
-          const { fileName, csvData } = matchedCustomFileLoader.convert(event, file);
+    const csvFilePromise: Promise<File> = matchedCustomFileLoader
+      ? loadFile(file).then((event) => {
+          const { fileName, csvData } = matchedCustomFileLoader.convert(
+            event,
+            file
+          );
 
           const csvBlob = new Blob([csvData], { type: 'text/csv' });
           const csvFile = new File([csvBlob], fileName, {
@@ -99,7 +100,7 @@ function ImporterBody({
         })
       : Promise.resolve(file);
 
-    csvFilePromise.then(csvFile => {
+    csvFilePromise.then((csvFile) => {
       parseCsv({
         file: csvFile,
         onCompleted: async (newParsed) => {
@@ -123,7 +124,7 @@ function ImporterBody({
           });
         },
       });
-    })
+    });
   }
 
   function onEnterDataManually() {

--- a/src/importer/index.tsx
+++ b/src/importer/index.tsx
@@ -23,7 +23,7 @@ import { Button, Root, Tooltip } from '../components';
 import { TranslationProvider, useTranslations } from '../i18';
 import BackToMappingButton from './components/BackToMappingButton';
 import { Uploader } from '../uploader';
-import { loadFile } from '../uploader/utils';
+import { convertCsvFile } from '../uploader/utils';
 
 function ImporterBody({
   theme,
@@ -80,27 +80,8 @@ function ImporterBody({
   const preventUpload = preventUploadOnErrors && validationErrors.length > 0;
 
   function onFileUploaded(file: File) {
-    const matchedCustomFileLoader = customFileLoaders?.find(
-      (loader) => loader.mimeType === file.type
-    );
 
-    const csvFilePromise: Promise<File> = matchedCustomFileLoader
-      ? loadFile(file).then((event) => {
-          const { fileName, csvData } = matchedCustomFileLoader.convert(
-            event,
-            file
-          );
-
-          const csvBlob = new Blob([csvData], { type: 'text/csv' });
-          const csvFile = new File([csvBlob], fileName, {
-            type: 'text/csv',
-          });
-
-          return csvFile;
-        })
-      : Promise.resolve(file);
-
-    csvFilePromise.then((csvFile) => {
+    convertCsvFile(file, customFileLoaders).then((csvFile) => {
       parseCsv({
         file: csvFile,
         onCompleted: async (newParsed) => {

--- a/src/importer/index.tsx
+++ b/src/importer/index.tsx
@@ -80,7 +80,6 @@ function ImporterBody({
   const preventUpload = preventUploadOnErrors && validationErrors.length > 0;
 
   function onFileUploaded(file: File) {
-
     convertCsvFile(file, customFileLoaders).then((csvFile) => {
       parseCsv({
         file: csvFile,

--- a/src/importer/index.tsx
+++ b/src/importer/index.tsx
@@ -29,6 +29,7 @@ function ImporterBody({
   onComplete,
   allowManualDataEntry,
   sheets,
+  customFileLoaders,
   onDataColumnsMapped,
   preventUploadOnValidationErrors,
   maxFileSizeInBytes = 20 * 1024 * 1024, // 20MB,
@@ -200,6 +201,7 @@ function ImporterBody({
             onEnterDataManually={onEnterDataManually}
             allowManualDataEntry={allowManualDataEntry}
             maxFileSizeInBytes={maxFileSizeInBytes}
+            customFileLoaders={customFileLoaders}
           />
         )}
 

--- a/src/importer/types.ts
+++ b/src/importer/types.ts
@@ -27,8 +27,8 @@ export interface ImporterDefinition {
   ) => Promise<void> | Promise<ImportStatistics>;
   locale?: string;
   preventUploadOnValidationErrors?:
-  | boolean
-  | ((errors: ImporterValidationError[]) => boolean);
+    | boolean
+    | ((errors: ImporterValidationError[]) => boolean);
   maxFileSizeInBytes?: number;
   onSummaryFinished?: () => void;
   customSuggestedMapper?: (
@@ -86,29 +86,29 @@ export interface RemoveRowsPayload {
 
 export type ImporterAction =
   | {
-    type: 'ENTER_DATA_MANUALLY';
-    payload: {
-      amountOfEmptyRowsToAdd: number;
-    };
-  } // Changes the mode to 'preview'
+      type: 'ENTER_DATA_MANUALLY';
+      payload: {
+        amountOfEmptyRowsToAdd: number;
+      };
+    } // Changes the mode to 'preview'
   | {
-    type: 'FILE_PARSED';
-    payload: { parsed: ParsedFile; rowFile: File };
-  } // Sets the parsed file and changes the mode to 'mapping'
+      type: 'FILE_PARSED';
+      payload: { parsed: ParsedFile; rowFile: File };
+    } // Sets the parsed file and changes the mode to 'mapping'
   | { type: 'UPLOAD' } // Changes the mode to 'upload' - used when going back from in the mapping screen
   | { type: 'COLUMN_MAPPING_CHANGED'; payload: { mappings: ColumnMapping[] } } // Sets the proper mappings
   | { type: 'DATA_MAPPED'; payload: { mappedData: MappedData } } // Sets mapped data as sheetData, optionally runs onDataColumnsMapped callback calls validations, changes the mode to 'preview'
   | {
-    type: 'CELL_CHANGED';
-    payload: CellChangedPayload;
-  } // Searches for the cell and changes the value, calls validations
+      type: 'CELL_CHANGED';
+      payload: CellChangedPayload;
+    } // Searches for the cell and changes the value, calls validations
   | {
-    type: 'REMOVE_ROWS';
-    payload: RemoveRowsPayload;
-  } // Removes rows from the sheetData
+      type: 'REMOVE_ROWS';
+      payload: RemoveRowsPayload;
+    } // Removes rows from the sheetData
   | {
-    type: 'ADD_EMPTY_ROW';
-  } // Removes rows from the sheetData
+      type: 'ADD_EMPTY_ROW';
+    } // Removes rows from the sheetData
   | { type: 'SHEET_CHANGED'; payload: { sheetId: string } } // Calls onComplete callback with state.sheetData, changes mode to 'submit'
   | { type: 'SUBMIT' } // Calls onComplete callback with state.sheetData, changes mode to 'submit'
   | { type: 'PROGRESS'; payload: { progress: number } } // Updates importProgress

--- a/src/importer/types.ts
+++ b/src/importer/types.ts
@@ -9,6 +9,7 @@ import {
   ColumnMapping,
   SheetRow,
   ImportStatistics,
+  CustomFileLoader,
 } from '../types';
 
 // --------- Importer Definition Types ---------
@@ -18,6 +19,7 @@ export interface ImporterDefinition {
   theme?: ThemeVariant;
   // Called after the columns are mapped to sheet definitions by the user
   onDataColumnsMapped?: OnDataColumnsMappedCallback;
+  customFileLoaders?: CustomFileLoader[];
   allowManualDataEntry?: boolean;
   onComplete: (
     state: ImporterState,
@@ -25,8 +27,8 @@ export interface ImporterDefinition {
   ) => Promise<void> | Promise<ImportStatistics>;
   locale?: string;
   preventUploadOnValidationErrors?:
-    | boolean
-    | ((errors: ImporterValidationError[]) => boolean);
+  | boolean
+  | ((errors: ImporterValidationError[]) => boolean);
   maxFileSizeInBytes?: number;
   onSummaryFinished?: () => void;
   customSuggestedMapper?: (
@@ -84,29 +86,29 @@ export interface RemoveRowsPayload {
 
 export type ImporterAction =
   | {
-      type: 'ENTER_DATA_MANUALLY';
-      payload: {
-        amountOfEmptyRowsToAdd: number;
-      };
-    } // Changes the mode to 'preview'
+    type: 'ENTER_DATA_MANUALLY';
+    payload: {
+      amountOfEmptyRowsToAdd: number;
+    };
+  } // Changes the mode to 'preview'
   | {
-      type: 'FILE_PARSED';
-      payload: { parsed: ParsedFile; rowFile: File };
-    } // Sets the parsed file and changes the mode to 'mapping'
+    type: 'FILE_PARSED';
+    payload: { parsed: ParsedFile; rowFile: File };
+  } // Sets the parsed file and changes the mode to 'mapping'
   | { type: 'UPLOAD' } // Changes the mode to 'upload' - used when going back from in the mapping screen
   | { type: 'COLUMN_MAPPING_CHANGED'; payload: { mappings: ColumnMapping[] } } // Sets the proper mappings
   | { type: 'DATA_MAPPED'; payload: { mappedData: MappedData } } // Sets mapped data as sheetData, optionally runs onDataColumnsMapped callback calls validations, changes the mode to 'preview'
   | {
-      type: 'CELL_CHANGED';
-      payload: CellChangedPayload;
-    } // Searches for the cell and changes the value, calls validations
+    type: 'CELL_CHANGED';
+    payload: CellChangedPayload;
+  } // Searches for the cell and changes the value, calls validations
   | {
-      type: 'REMOVE_ROWS';
-      payload: RemoveRowsPayload;
-    } // Removes rows from the sheetData
+    type: 'REMOVE_ROWS';
+    payload: RemoveRowsPayload;
+  } // Removes rows from the sheetData
   | {
-      type: 'ADD_EMPTY_ROW';
-    } // Removes rows from the sheetData
+    type: 'ADD_EMPTY_ROW';
+  } // Removes rows from the sheetData
   | { type: 'SHEET_CHANGED'; payload: { sheetId: string } } // Calls onComplete callback with state.sheetData, changes mode to 'submit'
   | { type: 'SUBMIT' } // Calls onComplete callback with state.sheetData, changes mode to 'submit'
   | { type: 'PROGRESS'; payload: { progress: number } } // Updates importProgress

--- a/src/uploader/components/FileUploader.tsx
+++ b/src/uploader/components/FileUploader.tsx
@@ -3,7 +3,7 @@ import { Button, Card } from '../../components';
 import { CloudArrowUpIcon } from '@heroicons/react/24/outline';
 import { useTranslations } from '../../i18';
 import { SUPPORTED_FILE_MIME_TYPES } from '../../constants';
-import { formatFileSize, loadFile } from '../utils';
+import { formatFileSize } from '../utils';
 import { CustomFileLoader } from '../../types';
 
 interface Props {
@@ -33,21 +33,6 @@ export default function FileUploader({
       return;
     }
 
-    const matchedCustomFileLoader = customFileLoaders?.find(loader => loader.mimeType === file.type);
-    if (matchedCustomFileLoader) {
-      loadFile(file).then(event => {
-        const { fileName, csvData } = matchedCustomFileLoader.convert(event ,file);
-
-        const csvBlob = new Blob([csvData], { type: 'text/csv' });
-        const csvFile = new File([csvBlob], fileName, {
-          type: 'text/csv',
-        });
-        setFile(csvFile);
-      })
-      
-      return;
-    }
-
     if (file.size <= maxFileSizeInBytes) {
       setFile(file);
     }
@@ -71,9 +56,7 @@ export default function FileUploader({
   return (
     <Card variant="muted" withPadding={false} className="h-full">
       <div
-        className={`flex h-full flex-col p-5 transition-colors ${
-          isDragging ? 'bg-hello-csv-muted-light' : 'bg-hello-csv-muted'
-        }`}
+        className={`flex h-full flex-col p-5 transition-colors ${isDragging ? 'bg-hello-csv-muted-light' : 'bg-hello-csv-muted'}`}
         onClick={() => fileInputRef.current?.click()}
         onDragOver={(e) => {
           e.preventDefault();

--- a/src/uploader/components/FileUploader.tsx
+++ b/src/uploader/components/FileUploader.tsx
@@ -24,11 +24,12 @@ export default function FileUploader({
   const { t, tHtml } = useTranslations();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [isDragging, setIsDragging] = useState(false);
-  const supportedMimeTypes = SUPPORTED_FILE_MIME_TYPES.concat(customFileLoaders?.map(loader => loader.mimeType) ?? []);
+  const supportedMimeTypes = SUPPORTED_FILE_MIME_TYPES.concat(
+    customFileLoaders?.map((loader) => loader.mimeType) ?? []
+  );
 
   // TODO: Add error handling
   const validateAndSetFile = (file: File, maxFileSizeInBytes: number) => {
-
     if (!supportedMimeTypes.includes(file.type)) {
       return;
     }
@@ -73,7 +74,10 @@ export default function FileUploader({
             {tHtml('uploader.maxFileSizeInBytes', {
               size: <b>{formatFileSize(maxFileSizeInBytes)}</b>,
             })}{' '}
-            • {["CSV", "TSV"].concat(customFileLoaders?.map(loader => loader.label) ?? []).join(", ")}
+            •{' '}
+            {['CSV', 'TSV']
+              .concat(customFileLoaders?.map((loader) => loader.label) ?? [])
+              .join(', ')}
           </div>
           <div className="mt-3">
             <Button>{t('uploader.browseFiles')}</Button>

--- a/src/uploader/components/Uploader.tsx
+++ b/src/uploader/components/Uploader.tsx
@@ -1,4 +1,4 @@
-import { SheetDefinition } from '../../types';
+import { CustomFileLoader, SheetDefinition } from '../../types';
 import ImporterRequirements from './ImporterRequirements';
 import FileUploader from './FileUploader';
 import { getImporterRequirements } from '../utils';
@@ -10,6 +10,7 @@ interface Props {
   onEnterDataManually: () => void;
   allowManualDataEntry?: boolean;
   maxFileSizeInBytes: number;
+  customFileLoaders?: CustomFileLoader[];
 }
 
 export default function Uploader({
@@ -18,6 +19,7 @@ export default function Uploader({
   onEnterDataManually,
   allowManualDataEntry,
   maxFileSizeInBytes,
+  customFileLoaders,
 }: Props) {
   const importerRequirements = getImporterRequirements(sheets);
   const { t } = useTranslations();
@@ -36,6 +38,7 @@ export default function Uploader({
               allowManualDataEntry={allowManualDataEntry}
               onEnterDataManually={onEnterDataManually}
               maxFileSizeInBytes={maxFileSizeInBytes}
+              customFileLoaders={customFileLoaders}
             />
           </div>
         </div>

--- a/src/uploader/types.ts
+++ b/src/uploader/types.ts
@@ -9,11 +9,13 @@ export type ImporterRequirementsType = {
   optional: ImporterRequirementType[];
 };
 
-
 export interface CustomFileLoader {
   mimeType: string;
   label: string;
-  convert: (loadEvent: ProgressEvent<FileReader>, file: File) => {
+  convert: (
+    loadEvent: ProgressEvent<FileReader>,
+    file: File
+  ) => {
     fileName: string;
     csvData: string;
   };

--- a/src/uploader/types.ts
+++ b/src/uploader/types.ts
@@ -15,8 +15,13 @@ export interface CustomFileLoader {
   convert: (
     loadEvent: ProgressEvent<FileReader>,
     file: File
-  ) => {
-    fileName: string;
-    csvData: string;
-  };
+  ) =>
+    | {
+        fileName: string;
+        csvData: string;
+      }
+    | Promise<{
+        fileName: string;
+        csvData: string;
+      }>;
 }

--- a/src/uploader/types.ts
+++ b/src/uploader/types.ts
@@ -8,3 +8,13 @@ export type ImporterRequirementsType = {
   required: ImporterRequirementType[];
   optional: ImporterRequirementType[];
 };
+
+
+export interface CustomFileLoader {
+  mimeType: string;
+  label: string;
+  convert: (loadEvent: ProgressEvent<FileReader>, file: File) => {
+    fileName: string;
+    csvData: string;
+  };
+}

--- a/src/uploader/utils.ts
+++ b/src/uploader/utils.ts
@@ -44,3 +44,13 @@ export const formatFileSize = (bytes: number): string => {
 
   return `${Math.round(size)} ${units[unitIndex]}`;
 };
+
+export const loadFile = async (file: File): Promise<ProgressEvent<FileReader>> => {
+  return new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      resolve(event);
+    };
+    reader.readAsArrayBuffer(file);
+  });
+}

--- a/src/uploader/utils.ts
+++ b/src/uploader/utils.ts
@@ -58,25 +58,25 @@ const loadFile = async (file: File): Promise<ProgressEvent<FileReader>> => {
 export const convertCsvFile = async (
   file: File,
   customFileLoaders: CustomFileLoader[] | undefined
-) => {
+): Promise<File> => {
   const matchedCustomFileLoader = customFileLoaders?.find(
     (loader) => loader.mimeType === file.type
   );
 
   if (matchedCustomFileLoader) {
-    return loadFile(file).then((event) => {
-      const { fileName, csvData } = matchedCustomFileLoader.convert(
-        event,
-        file
-      );
+    const loadedEvent = await loadFile(file);
 
-      const csvBlob = new Blob([csvData], { type: 'text/csv' });
-      const csvFile = new File([csvBlob], fileName, {
-        type: 'text/csv',
-      });
+    const { fileName, csvData } = await matchedCustomFileLoader.convert(
+      loadedEvent,
+      file
+    );
 
-      return csvFile;
+    const csvBlob = new Blob([csvData], { type: 'text/csv' });
+    const csvFile = new File([csvBlob], fileName, {
+      type: 'text/csv',
     });
+
+    return csvFile;
   }
 
   return file;

--- a/src/uploader/utils.ts
+++ b/src/uploader/utils.ts
@@ -45,7 +45,9 @@ export const formatFileSize = (bytes: number): string => {
   return `${Math.round(size)} ${units[unitIndex]}`;
 };
 
-export const loadFile = async (file: File): Promise<ProgressEvent<FileReader>> => {
+export const loadFile = async (
+  file: File
+): Promise<ProgressEvent<FileReader>> => {
   return new Promise((resolve) => {
     const reader = new FileReader();
     reader.onload = (event) => {
@@ -53,4 +55,4 @@ export const loadFile = async (file: File): Promise<ProgressEvent<FileReader>> =
     };
     reader.readAsArrayBuffer(file);
   });
-}
+};


### PR DESCRIPTION
## Problem

we need another csv like file type support (like xlsx)

But... library like xlsx is very large and heavy. https://github.com/HelloCSV/HelloCSV/pull/136

## Solution

add `customFileLoaders` option. we can add new `mimeType` support with `convert` function to convert a file into csv format string.