### PR TITLE
feat: use label in enum's reference column

### DIFF
--- a/src/importer/index.tsx
+++ b/src/importer/index.tsx
@@ -24,6 +24,7 @@ import { TranslationProvider, useTranslations } from '../i18';
 import BackToMappingButton from './components/BackToMappingButton';
 import { Uploader } from '../uploader';
 import { convertCsvFile } from '../uploader/utils';
+import { getEnumLabelDict } from '../sheet/utils';
 
 function ImporterBody({
   theme,
@@ -72,24 +73,7 @@ function ImporterBody({
     (sheet) => sheet.id === currentSheetId
   )!;
 
-  const enumLabelDict = Object.fromEntries(
-    sheets.map((sheet) => [
-      sheet.id,
-      Object.fromEntries(
-        sheet.columns
-          .filter((column) => column.type === 'enum')
-          .map((column) => [
-            column.id,
-            Object.fromEntries(
-              column.typeArguments.values.map(({ label, value }) => [
-                value,
-                label,
-              ])
-            ),
-          ])
-      ),
-    ])
-  );
+  const enumLabelDict = getEnumLabelDict(sheets);
 
   const preventUploadOnErrors =
     typeof preventUploadOnValidationErrors === 'function'

--- a/src/importer/index.tsx
+++ b/src/importer/index.tsx
@@ -72,6 +72,25 @@ function ImporterBody({
     (sheet) => sheet.id === currentSheetId
   )!;
 
+  const enumLabelDict = Object.fromEntries(
+    sheets.map((sheet) => [
+      sheet.id,
+      Object.fromEntries(
+        sheet.columns
+          .filter((column) => column.type === 'enum')
+          .map((column) => [
+            column.id,
+            Object.fromEntries(
+              column.typeArguments.values.map(({ label, value }) => [
+                value,
+                label,
+              ])
+            ),
+          ])
+      ),
+    ])
+  );
+
   const preventUploadOnErrors =
     typeof preventUploadOnValidationErrors === 'function'
       ? (preventUploadOnValidationErrors?.(validationErrors) ?? false)
@@ -243,6 +262,7 @@ function ImporterBody({
                 removeRows={onRemoveRows}
                 addEmptyRow={addEmptyRow}
                 resetState={resetState}
+                enumLabelDict={enumLabelDict}
               />
             </div>
             <div className="flex-none">

--- a/src/sheet/components/SheetDataEditor.tsx
+++ b/src/sheet/components/SheetDataEditor.tsx
@@ -27,6 +27,13 @@ interface Props {
   removeRows: (payload: RemoveRowsPayload) => void;
   addEmptyRow: () => void;
   resetState: () => void;
+  enumLabelDict: {
+    [sheetId: string]: {
+      [columnId: string]: {
+        [value: string]: ImporterOutputFieldType;
+      };
+    };
+  };
 }
 
 export default function SheetDataEditor({
@@ -38,6 +45,7 @@ export default function SheetDataEditor({
   removeRows,
   addEmptyRow,
   resetState,
+  enumLabelDict,
 }: Props) {
   const [selectedRows, setSelectedRows] = useState<SheetRow[]>([]);
   const [viewMode, setViewMode] = useState<SheetViewMode>('all');
@@ -143,6 +151,7 @@ export default function SheetDataEditor({
           onCellValueChanged={onCellValueChanged}
           selectedRows={selectedRows}
           setSelectedRows={setSelectedRows}
+          enumLabelDict={enumLabelDict}
         />
       </div>
     </div>

--- a/src/sheet/components/SheetDataEditor.tsx
+++ b/src/sheet/components/SheetDataEditor.tsx
@@ -6,7 +6,13 @@ import {
   useReactTable,
 } from '@tanstack/react-table';
 
-import { SheetDefinition, SheetState, SheetRow, SheetViewMode } from '../types';
+import {
+  SheetDefinition,
+  SheetState,
+  SheetRow,
+  SheetViewMode,
+  EnumLabelDict,
+} from '../types';
 import {
   CellChangedPayload,
   ImporterOutputFieldType,
@@ -27,13 +33,7 @@ interface Props {
   removeRows: (payload: RemoveRowsPayload) => void;
   addEmptyRow: () => void;
   resetState: () => void;
-  enumLabelDict: {
-    [sheetId: string]: {
-      [columnId: string]: {
-        [value: string]: ImporterOutputFieldType;
-      };
-    };
-  };
+  enumLabelDict: EnumLabelDict;
 }
 
 export default function SheetDataEditor({

--- a/src/sheet/components/SheetDataEditorCell.tsx
+++ b/src/sheet/components/SheetDataEditorCell.tsx
@@ -19,6 +19,13 @@ interface Props {
   allData: SheetState[];
   clearRowsSelection: () => void;
   errorsText: string;
+  enumLabelDict: {
+    [sheetId: string]: {
+      [columnId: string]: {
+        [value: string]: ImporterOutputFieldType;
+      };
+    };
+  };
 }
 
 export default function SheetDataEditorCell({
@@ -28,6 +35,7 @@ export default function SheetDataEditorCell({
   allData,
   clearRowsSelection,
   errorsText,
+  enumLabelDict,
 }: Props) {
   const { t } = useTranslations();
 
@@ -110,8 +118,11 @@ export default function SheetDataEditorCell({
       allData
     );
 
+    const { sheetId, sheetColumnId } = columnDefinition.typeArguments;
+    const labelDict = enumLabelDict[sheetId][sheetColumnId];
+
     const selectOptions = referenceData.map((value) => ({
-      label: value,
+      label: labelDict[value] ?? value,
       value,
     }));
 

--- a/src/sheet/components/SheetDataEditorCell.tsx
+++ b/src/sheet/components/SheetDataEditorCell.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'preact/hooks';
 import {
+  EnumLabelDict,
   ImporterOutputFieldType,
   SheetColumnDefinition,
   SheetState,
@@ -19,13 +20,7 @@ interface Props {
   allData: SheetState[];
   clearRowsSelection: () => void;
   errorsText: string;
-  enumLabelDict: {
-    [sheetId: string]: {
-      [columnId: string]: {
-        [value: string]: ImporterOutputFieldType;
-      };
-    };
-  };
+  enumLabelDict: EnumLabelDict;
 }
 
 export default function SheetDataEditorCell({
@@ -119,7 +114,7 @@ export default function SheetDataEditorCell({
     );
 
     const { sheetId, sheetColumnId } = columnDefinition.typeArguments;
-    const labelDict = enumLabelDict[sheetId][sheetColumnId];
+    const labelDict = enumLabelDict[sheetId][sheetColumnId] ?? {};
 
     const selectOptions = referenceData.map((value) => ({
       label: labelDict[value] ?? value,

--- a/src/sheet/components/SheetDataEditorTable.tsx
+++ b/src/sheet/components/SheetDataEditorTable.tsx
@@ -20,6 +20,13 @@ interface Props {
   ) => void;
   selectedRows: SheetRow[];
   setSelectedRows: (rows: SheetRow[]) => void;
+  enumLabelDict: {
+    [sheetId: string]: {
+      [columnId: string]: {
+        [value: string]: ImporterOutputFieldType;
+      };
+    };
+  };
 }
 
 export default function SheetDataEditorTable({
@@ -31,6 +38,7 @@ export default function SheetDataEditorTable({
   onCellValueChanged,
   selectedRows,
   setSelectedRows,
+  enumLabelDict,
 }: Props) {
   const { t } = useTranslations();
 
@@ -61,7 +69,7 @@ export default function SheetDataEditorTable({
   }
 
   const headerClass =
-    'bg-hello-csv-muted py-3.5 pr-3 pl-4 text-left text-sm font-semibold text-gray-900 whitespace-nowrap border-y border-gray-300';
+    'bg-hello-csv-muted py-3.5 pr-3 pl-4 text-left text-sm font-semibold text-gray-900 whitespace-nowrap border-y border-gray-300 shrink-0';
   const cellClass =
     'text-sm font-medium whitespace-nowrap text-gray-900 border-b border-gray-300 max-w-[350px]';
 
@@ -156,6 +164,7 @@ export default function SheetDataEditorTable({
                     }
                     clearRowsSelection={() => setSelectedRows([])}
                     errorsText={cellErrorsText}
+                    enumLabelDict={enumLabelDict}
                   />
                 </td>
               );

--- a/src/sheet/components/SheetDataEditorTable.tsx
+++ b/src/sheet/components/SheetDataEditorTable.tsx
@@ -1,6 +1,6 @@
 import { flexRender, Table } from '@tanstack/react-table';
 import SheetDataEditorCell from './SheetDataEditorCell';
-import { SheetDefinition, SheetRow, SheetState } from '../types';
+import { EnumLabelDict, SheetDefinition, SheetRow, SheetState } from '../types';
 import { ImporterOutputFieldType, ImporterValidationError } from '../../types';
 import { Checkbox } from '../../components';
 import { useTranslations } from '../../i18';
@@ -20,13 +20,7 @@ interface Props {
   ) => void;
   selectedRows: SheetRow[];
   setSelectedRows: (rows: SheetRow[]) => void;
-  enumLabelDict: {
-    [sheetId: string]: {
-      [columnId: string]: {
-        [value: string]: ImporterOutputFieldType;
-      };
-    };
-  };
+  enumLabelDict: EnumLabelDict;
 }
 
 export default function SheetDataEditorTable({
@@ -69,7 +63,7 @@ export default function SheetDataEditorTable({
   }
 
   const headerClass =
-    'bg-hello-csv-muted py-3.5 pr-3 pl-4 text-left text-sm font-semibold text-gray-900 whitespace-nowrap border-y border-gray-300 shrink-0';
+    'bg-hello-csv-muted py-3.5 pr-3 pl-4 text-left text-sm font-semibold text-gray-900 whitespace-nowrap border-y border-gray-300';
   const cellClass =
     'text-sm font-medium whitespace-nowrap text-gray-900 border-b border-gray-300 max-w-[350px]';
 

--- a/src/sheet/types.ts
+++ b/src/sheet/types.ts
@@ -62,6 +62,14 @@ interface SheetColumnCalculatedDefinition
   };
 }
 
+export type EnumLabelDict = {
+  [sheetId: string]: {
+    [columnId: string]: {
+      [value: string]: ImporterOutputFieldType;
+    };
+  };
+};
+
 // --------- Sheet State Types ---------
 export type SheetRow = Record<string, ImporterOutputFieldType>;
 

--- a/src/sheet/utils.ts
+++ b/src/sheet/utils.ts
@@ -131,3 +131,24 @@ export function isColumnReadOnly(
 
   return !!columnDefinition.isReadOnly;
 }
+
+export function getEnumLabelDict(sheetDefinitions: SheetDefinition[]) {
+  return Object.fromEntries(
+    sheetDefinitions.map((sheet) => [
+      sheet.id,
+      Object.fromEntries(
+        sheet.columns
+          .filter((column) => column.type === 'enum')
+          .map((column) => [
+            column.id,
+            Object.fromEntries(
+              column.typeArguments.values.map(({ label, value }) => [
+                value,
+                label,
+              ])
+            ),
+          ])
+      ),
+    ])
+  );
+}


### PR DESCRIPTION
## Problem

we have a enum field(category-id 카테고리), and a field which reference the enum field(another sheet's category-id)
![image](https://github.com/user-attachments/assets/43b3647e-f262-4ce9-9eb5-0235cbb32578)
![image](https://github.com/user-attachments/assets/4b5ed5f3-ea96-4013-b909-bffe4fa983bf)

but it rendered as value(the actual id), not label in referece column

## Solution

find the reference sheet's enum with enumLabelDict (sheetId -> columId -> enum value -> enum label)
