### PR TITLE
feat: show sheet's row count on SheetsSwitcher tab

### DIFF
--- a/src/importer/index.tsx
+++ b/src/importer/index.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from 'preact/hooks';
+import { useRef, useEffect, useMemo } from 'preact/hooks';
 
 import HeaderMapper from '../mapper/components/HeaderMapper';
 import SheetDataEditor from '../sheet/components/SheetDataEditor';
@@ -68,6 +68,12 @@ function ImporterBody({
   const currentSheetData = sheetData.find(
     (sheet) => sheet.sheetId === currentSheetId
   )!;
+
+  const sheetCountDict = useMemo(() => {
+    return Object.fromEntries(
+      sheetData.map((sheet) => [sheet.sheetId, sheet.rows.length])
+    );
+  }, [sheetData]);
 
   const currentSheetDefinition = sheets.find(
     (sheet) => sheet.id === currentSheetId
@@ -228,6 +234,7 @@ function ImporterBody({
               <SheetsSwitcher
                 activeSheetId={currentSheetId}
                 sheetDefinitions={sheets}
+                sheetCountDict={sheetCountDict}
                 onSheetChange={(sheetId) =>
                   dispatch({ type: 'SHEET_CHANGED', payload: { sheetId } })
                 }

--- a/src/sheet/components/SheetsSwitcher.tsx
+++ b/src/sheet/components/SheetsSwitcher.tsx
@@ -8,6 +8,7 @@ interface Props {
   activeSheetId: string;
   onSheetChange: (sheetId: string) => void;
   validationErrors: ImporterValidationError[];
+  sheetCountDict: Record<string, number>;
 }
 
 export default function SheetsSwitcher({
@@ -15,11 +16,12 @@ export default function SheetsSwitcher({
   activeSheetId,
   onSheetChange,
   validationErrors,
+  sheetCountDict,
 }: Props) {
   return (
     <Tabs
       tabs={sheetDefinitions.map((sheet) => ({
-        label: sheet.label,
+        label: sheet.label + ` (${sheetCountDict[sheet.id]})`,
         value: sheet.id,
         icon: validationErrors.some((error) => error.sheetId === sheet.id) ? (
           <ExclamationCircleIcon className="mr-3 h-4 w-4" />


### PR DESCRIPTION
## Before
we can't see tab's rows' count

<img width="629" alt="image" src="https://github.com/user-attachments/assets/b312e200-c580-4437-903c-33830955809c" />


## After
<img width="432" alt="image" src="https://github.com/user-attachments/assets/5b33d103-58dd-4f36-ab70-388dda0b39bb" />
