### PR TITLE
fix: duplicate react keys in Select component

### DIFF
--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -1,18 +1,18 @@
 import {
   Combobox,
   ComboboxButton,
+  ComboboxInput,
   ComboboxOption,
   ComboboxOptions,
-  ComboboxInput,
 } from '@headlessui/react';
 import {
+  CheckIcon,
   ChevronUpDownIcon,
   XMarkIcon,
-  CheckIcon,
 } from '@heroicons/react/20/solid';
-import { useTranslations } from '../i18';
-import { useState } from 'preact/hooks';
 import { ReactNode } from 'preact/compat';
+import { useState } from 'preact/hooks';
+import { useTranslations } from '../i18';
 
 export interface SelectOption<T> {
   label: string;
@@ -190,9 +190,13 @@ export default function Select<T>({
                   {label}
                 </div>
               )}
-              {items.map((option) => (
+              {items.map((option, index) => (
                 <ComboboxOption
-                  key={option.value as string}
+                  key={
+                    typeof option.value === 'object' && option.value !== null
+                      ? `${option.label}-${index}`
+                      : String(option.value)
+                  }
                   value={option.value}
                   className="group data-focus:bg-hello-csv-primary relative flex cursor-default items-center py-2 pr-9 pl-3 text-gray-900 select-none data-focus:text-white data-focus:outline-hidden"
                 >

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -1,18 +1,18 @@
 import {
   Combobox,
   ComboboxButton,
-  ComboboxInput,
   ComboboxOption,
   ComboboxOptions,
+  ComboboxInput,
 } from '@headlessui/react';
 import {
-  CheckIcon,
   ChevronUpDownIcon,
   XMarkIcon,
+  CheckIcon,
 } from '@heroicons/react/20/solid';
-import { ReactNode } from 'preact/compat';
-import { useState } from 'preact/hooks';
 import { useTranslations } from '../i18';
+import { useState } from 'preact/hooks';
+import { ReactNode } from 'preact/compat';
 
 export interface SelectOption<T> {
   label: string;
@@ -190,11 +190,11 @@ export default function Select<T>({
                   {label}
                 </div>
               )}
-              {items.map((option, index) => (
+              {items.map((option) => (
                 <ComboboxOption
                   key={
-                    typeof option.value === 'object' && option.value !== null
-                      ? `${option.label}-${index}`
+                    typeof option.value === 'object'
+                      ? JSON.stringify(option.value)
                       : String(option.value)
                   }
                   value={option.value}


### PR DESCRIPTION
## Problem
The Select component generates duplicate React keys when using object values, causing the warning: 
```
Encountered two children with the same key, `[object Object]`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
```

Here's a reproducible codesandbox as well:
https://codesandbox.io/p/sandbox/rrfwlt

---

This happens specifically in the column mapping step when `MapperOptionValue` objects are used as keys.

## Solution
Updated the key generation logic to create unique string keys:
- For object values: stringified object
- For primitive values: `String(value)` (maintaining existing behavior for strings, numbers, etc.)

This approach ensures unique keys while using meaningful, readable identifiers based on the option labels.

## Reproduction Steps
1. Upload a CSV file with multiple columns
2. Open browser console
3. Click on any select dropdown in the column mapping screen
4. See the duplicate key warning (before fix) or no warning (after fix)